### PR TITLE
Entities

### DIFF
--- a/resources/views/partials/breadcrumbs.blade.php
+++ b/resources/views/partials/breadcrumbs.blade.php
@@ -6,12 +6,12 @@
 				<span class="breadcrumb-item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 				@if ( empty( $item['link'] ) )
 						<span itemscope itemtype="http://schema.org/Thing" itemprop="item">
-						<span itemprop="name">{{ esc_html( $item['title'] ) }}</span>
+						<span itemprop="name">{!! $item['title'] !!}</span>
 					</span>
 					@else
 						<a itemscope itemtype="http://schema.org/Thing" itemprop="item"
 						   href="{{ esc_url( $item['link'] ) }}"><span
-									itemprop="name">{{ esc_html( $item['title'] ) }}</span></a>
+									itemprop="name">{!! $item['title'] !!}</span></a>
 					@endif
 					<meta itemprop="position" content="<?php echo esc_attr( $key + 1 ); ?>"/>
 				</span>


### PR DESCRIPTION
ref: https://laravel.com/docs/5.8/blade 

`{!! - !!}` doesn't sent content through `htmlspecialchars()` whereas `{{ }}` does. This eliminates creating html entities and then immediately decoding those entities. 